### PR TITLE
Backport windows to 2020.2

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,10 +8,11 @@ jobs:
     vmImage: ubuntu-16.04
   strategy:
     matrix:
-      linux_64_:
-        CONFIG: linux_64_
+      linux_target_platformlinux-64:
+        CONFIG: linux_target_platformlinux-64
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: condaforge/linux-anvil-comp7
+    maxParallel: 8
   timeoutInMinutes: 360
 
   steps:

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -5,12 +5,13 @@
 jobs:
 - job: osx
   pool:
-    vmImage: macOS-10.15
+    vmImage: macOS-10.14
   strategy:
     matrix:
-      osx_64_:
-        CONFIG: osx_64_
+      osx_:
+        CONFIG: osx_
         UPLOAD_PACKAGES: 'True'
+    maxParallel: 8
   timeoutInMinutes: 360
 
   steps:

--- a/.ci_support/linux_target_platformlinux-64.yaml
+++ b/.ci_support/linux_target_platformlinux-64.yaml
@@ -1,15 +1,8 @@
-cdt_name:
-- cos6
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
 docker_image:
 - condaforge/linux-anvil-comp7
-mkl:
-- '2019'
-pin_run_as_build:
-  mkl:
-    max_pin: x
 target_platform:
 - linux-64

--- a/.ci_support/osx_.yaml
+++ b/.ci_support/osx_.yaml
@@ -6,10 +6,7 @@ channel_targets:
 - conda-forge main
 macos_machine:
 - x86_64-apple-darwin13.4.0
-mkl:
-- '2019'
-pin_run_as_build:
-  mkl:
-    max_pin: x
+macos_min_version:
+- '10.9'
 target_platform:
 - osx-64

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -19,7 +19,7 @@ conda-build:
 
 CONDARC
 
-conda install --yes --quiet "conda-forge-ci-setup=3" conda-build pip -c conda-forge
+conda install --yes --quiet conda-forge-ci-setup=3 conda-build pip -c conda-forge
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
@@ -29,25 +29,13 @@ source run_conda_forge_build_setup
 # make the build number clobber
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
+conda build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+    --suppress-variables \
+    --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
+validate_recipe_outputs "${FEEDSTOCK_NAME}"
 
-if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
-    if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then
-        EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --output-id ${BUILD_OUTPUT_ID}"
-    fi
-    conda debug "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
-        ${EXTRA_CB_OPTIONS:-} \
-        --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
-    # Drop into an interactive shell
-    /bin/bash
-else
-    conda build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
-        --suppress-variables ${EXTRA_CB_OPTIONS:-} \
-        --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
-    validate_recipe_outputs "${FEEDSTOCK_NAME}"
-
-    if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
-        upload_package --validate --feedstock-name="${FEEDSTOCK_NAME}"  "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
-    fi
+if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
+    upload_package --validate --feedstock-name="${FEEDSTOCK_NAME}"  "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 fi
 
 touch "${FEEDSTOCK_ROOT}/build_artifacts/conda-forge-build-done-${CONFIG}"

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -74,8 +74,6 @@ docker run ${DOCKER_RUN_ARGS} \
            -e CI \
            -e FEEDSTOCK_NAME \
            -e CPU_COUNT \
-           -e BUILD_WITH_CONDA_DEBUG \
-           -e BUILD_OUTPUT_ID \
            -e BINSTAR_TOKEN \
            -e FEEDSTOCK_TOKEN \
            -e STAGING_BINSTAR_TOKEN \

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -23,7 +23,7 @@ source ${HOME}/miniforge3/etc/profile.d/conda.sh
 conda activate base
 
 echo -e "\n\nInstalling conda-forge-ci-setup=3 and conda-build."
-conda install -n base --quiet --yes "conda-forge-ci-setup=3" conda-build pip
+conda install -n base --quiet --yes conda-forge-ci-setup=3 conda-build pip
 
 
 
@@ -47,8 +47,7 @@ set -e
 
 echo -e "\n\nMaking the build clobber file and running the build."
 make_build_number ./ ./recipe ./.ci_support/${CONFIG}.yaml
-
-conda build ./recipe -m ./.ci_support/${CONFIG}.yaml --suppress-variables --clobber-file ./.ci_support/clobber_${CONFIG}.yaml ${EXTRA_CB_OPTIONS:-}
+conda build ./recipe -m ./.ci_support/${CONFIG}.yaml --suppress-variables --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
 validate_recipe_outputs "${FEEDSTOCK_NAME}"
 
 if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,5 @@
 BSD 3-clause license
-Copyright (c) 2015-2020, conda-forge contributors
+Copyright (c) 2015-2019, conda-forge
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/intel_repack-fe
 
 Summary: DAAL runtime libraries
 
+
+
 Current build status
 ====================
 
@@ -27,14 +29,14 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_64</td>
+              <td>linux_target_platformlinux-64</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8901&branchName=master">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/intel_repack-feedstock?branchName=master&jobName=linux&configuration=linux_64_" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64</td>
+              <td>osx</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8901&branchName=master">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/intel_repack-feedstock?branchName=master&jobName=osx&configuration=osx_64_" alt="variant">
@@ -51,6 +53,18 @@ Current build status
           </tbody>
         </table>
       </details>
+    </td>
+  </tr>
+  <tr>
+    <td>Windows</td>
+    <td>
+      <img src="https://img.shields.io/badge/Windows-disabled-lightgrey.svg" alt="Windows disabled">
+    </td>
+  </tr>
+  <tr>
+    <td>Linux_ppc64le</td>
+    <td>
+      <img src="https://img.shields.io/badge/ppc64le-disabled-lightgrey.svg" alt="ppc64le disabled">
     </td>
   </tr>
 </table>

--- a/build-locally.py
+++ b/build-locally.py
@@ -12,10 +12,6 @@ from argparse import ArgumentParser
 def setup_environment(ns):
     os.environ["CONFIG"] = ns.config
     os.environ["UPLOAD_PACKAGES"] = "False"
-    if ns.debug:
-        os.environ["BUILD_WITH_CONDA_DEBUG"] = "1"
-        if ns.output_id:
-            os.environ["BUILD_OUTPUT_ID"] = ns.output_id
 
 
 def run_docker_build(ns):
@@ -55,14 +51,6 @@ def verify_config(ns):
 def main(args=None):
     p = ArgumentParser("build-locally")
     p.add_argument("config", default=None, nargs="?")
-    p.add_argument(
-        "--debug",
-        action="store_true",
-        help="Setup debug environment using `conda debug`",
-    )
-    p.add_argument(
-        "--output-id", help="If running debug, specify the output to setup."
-    )
 
     ns = p.parse_args(args=args)
     verify_config(ns)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -86,8 +86,7 @@ outputs:
       license: LicenseRef-ProprietaryIntel
       license_family: Proprietary
       license_file:
-         - mkl/info/licenses/license.txt
-         - mkl/info/licenses/tpp.txt
+         - mkl/info/LICENSE.txt
       summary: Math library for Intel and compatible processors
       description: |
         Intel Math Kernel Library is a BLAS implementation tuned for high performance on Intel CPUs.
@@ -105,8 +104,7 @@ outputs:
       license: LicenseRef-ProprietaryIntel
       license_family: Proprietary
       license_file:
-         - mkl/info/licenses/license.txt
-         - mkl/info/licenses/tpp.txt
+         - mkl/info/LICENSE.txt
       summary: MKL headers for developing software that uses MKL
       description: |
         Intel Math Kernel Library is a BLAS implementation tuned for high performance on Intel CPUs.
@@ -127,8 +125,7 @@ outputs:
       license: LicenseRef-ProprietaryIntel
       license_family: Proprietary
       license_file:
-         - mkl/info/licenses/license.txt
-         - mkl/info/licenses/tpp.txt
+         - mkl/info/LICENSE.txt
       summary: Math library for Intel and compatible processors
       description: |
         Intel openmp runtime implementation
@@ -181,8 +178,7 @@ outputs:
       license: LicenseRef-ProprietaryIntel
       license_family: Proprietary
       license_file:
-         - mkl/info/licenses/license.txt
-         - mkl/info/licenses/tpp.txt
+         - mkl/info/LICENSE.txt
     test:
       commands:
         - ls -A $PREFIX/lib/*  # [unix]
@@ -231,8 +227,7 @@ outputs:
       license: LicenseRef-ProprietaryIntel
       license_family: Proprietary
       license_file:
-         - mkl/info/licenses/license.txt
-         - mkl/info/licenses/tpp.txt
+         - mkl/info/LICENSE.txt
     test:
       commands:
         - ls -A $PREFIX/lib/*  # [unix]
@@ -269,8 +264,7 @@ outputs:
       license: LicenseRef-ProprietaryIntel
       license_family: Proprietary
       license_file:
-         - mkl/info/licenses/license.txt
-         - mkl/info/licenses/tpp.txt
+         - mkl/info/LICENSE.txt
     test:
       commands:
         - ls -A $PREFIX/lib/*  # [unix]
@@ -292,8 +286,7 @@ outputs:
       license: LicenseRef-ProprietaryIntel
       license_family: Proprietary
       license_file:
-         - mkl/info/licenses/license.txt
-         - mkl/info/licenses/tpp.txt
+         - mkl/info/LICENSE.txt
     test:
       commands:
         - ls -A $PREFIX/lib/*  # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -86,7 +86,8 @@ outputs:
       license: LicenseRef-ProprietaryIntel
       license_family: Proprietary
       license_file:
-         - mkl/info/licenses/license.txt
+         - mkl/info/licenses/license.txt  # [not win]
+         - mkl/info/LICENSE.txt           # [win]
       summary: Math library for Intel and compatible processors
       description: |
         Intel Math Kernel Library is a BLAS implementation tuned for high performance on Intel CPUs.
@@ -104,7 +105,8 @@ outputs:
       license: LicenseRef-ProprietaryIntel
       license_family: Proprietary
       license_file:
-         - mkl/info/licenses/license.txt
+         - mkl/info/licenses/license.txt  # [not win]
+         - mkl/info/LICENSE.txt           # [win]
       summary: MKL headers for developing software that uses MKL
       description: |
         Intel Math Kernel Library is a BLAS implementation tuned for high performance on Intel CPUs.
@@ -125,7 +127,8 @@ outputs:
       license: LicenseRef-ProprietaryIntel
       license_family: Proprietary
       license_file:
-         - mkl/info/licenses/license.txt
+         - mkl/info/licenses/license.txt  # [not win]
+         - mkl/info/LICENSE.txt           # [win]
       summary: Math library for Intel and compatible processors
       description: |
         Intel openmp runtime implementation
@@ -178,7 +181,8 @@ outputs:
       license: LicenseRef-ProprietaryIntel
       license_family: Proprietary
       license_file:
-         - mkl/info/licenses/license.txt
+         - mkl/info/licenses/license.txt  # [not win]
+         - mkl/info/LICENSE.txt           # [win]
     test:
       commands:
         - ls -A $PREFIX/lib/*  # [unix]
@@ -227,7 +231,8 @@ outputs:
       license: LicenseRef-ProprietaryIntel
       license_family: Proprietary
       license_file:
-         - mkl/info/licenses/license.txt
+         - mkl/info/licenses/license.txt  # [not win]
+         - mkl/info/LICENSE.txt           # [win]
     test:
       commands:
         - ls -A $PREFIX/lib/*  # [unix]
@@ -243,7 +248,8 @@ outputs:
       license: LicenseRef-ProprietaryIntel
       license_family: Proprietary
       license_file:
-         - mkl/info/licenses/license.txt
+         - mkl/info/licenses/license.txt  # [not win]
+         - mkl/info/LICENSE.txt           # [win]
     test:
       commands:
         - ls -A $PREFIX/include/*  # [unix]
@@ -263,7 +269,8 @@ outputs:
       license: LicenseRef-ProprietaryIntel
       license_family: Proprietary
       license_file:
-         - mkl/info/licenses/license.txt
+         - mkl/info/licenses/license.txt  # [not win]
+         - mkl/info/LICENSE.txt           # [win]
     test:
       commands:
         - ls -A $PREFIX/lib/*  # [unix]
@@ -285,7 +292,8 @@ outputs:
       license: LicenseRef-ProprietaryIntel
       license_family: Proprietary
       license_file:
-         - mkl/info/licenses/license.txt
+         - mkl/info/licenses/license.txt  # [not win]
+         - mkl/info/LICENSE.txt           # [win]
     test:
       commands:
         - ls -A $PREFIX/lib/*  # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -86,7 +86,7 @@ outputs:
       license: LicenseRef-ProprietaryIntel
       license_family: Proprietary
       license_file:
-         - mkl/info/LICENSE.txt
+         - mkl/info/licenses/license.txt
       summary: Math library for Intel and compatible processors
       description: |
         Intel Math Kernel Library is a BLAS implementation tuned for high performance on Intel CPUs.
@@ -104,7 +104,7 @@ outputs:
       license: LicenseRef-ProprietaryIntel
       license_family: Proprietary
       license_file:
-         - mkl/info/LICENSE.txt
+         - mkl/info/licenses/license.txt
       summary: MKL headers for developing software that uses MKL
       description: |
         Intel Math Kernel Library is a BLAS implementation tuned for high performance on Intel CPUs.
@@ -125,7 +125,7 @@ outputs:
       license: LicenseRef-ProprietaryIntel
       license_family: Proprietary
       license_file:
-         - mkl/info/LICENSE.txt
+         - mkl/info/licenses/license.txt
       summary: Math library for Intel and compatible processors
       description: |
         Intel openmp runtime implementation
@@ -178,7 +178,7 @@ outputs:
       license: LicenseRef-ProprietaryIntel
       license_family: Proprietary
       license_file:
-         - mkl/info/LICENSE.txt
+         - mkl/info/licenses/license.txt
     test:
       commands:
         - ls -A $PREFIX/lib/*  # [unix]
@@ -227,7 +227,7 @@ outputs:
       license: LicenseRef-ProprietaryIntel
       license_family: Proprietary
       license_file:
-         - mkl/info/LICENSE.txt
+         - mkl/info/licenses/license.txt
     test:
       commands:
         - ls -A $PREFIX/lib/*  # [unix]
@@ -244,7 +244,6 @@ outputs:
       license_family: Proprietary
       license_file:
          - mkl/info/licenses/license.txt
-         - mkl/info/licenses/tpp.txt
     test:
       commands:
         - ls -A $PREFIX/include/*  # [unix]
@@ -264,7 +263,7 @@ outputs:
       license: LicenseRef-ProprietaryIntel
       license_family: Proprietary
       license_file:
-         - mkl/info/LICENSE.txt
+         - mkl/info/licenses/license.txt
     test:
       commands:
         - ls -A $PREFIX/lib/*  # [unix]
@@ -286,7 +285,7 @@ outputs:
       license: LicenseRef-ProprietaryIntel
       license_family: Proprietary
       license_file:
-         - mkl/info/LICENSE.txt
+         - mkl/info/licenses/license.txt
     test:
       commands:
         - ls -A $PREFIX/lib/*  # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,11 @@
-{% set mkl_version = "2020.4" %}
-{% set version = "2020.3" %}
-{% set buildnum = "304" %}  # [linux]
-{% set buildnum = "301" %}  # [osx]
-{% set buildnum = "311" %}  # [win]
+{% set version = "2020.2" %}
+{% set buildnum = "254" %}  # [not osx]
+{% set buildnum = "258" %}  # [osx]
 
 {% set my_channel_targets = channel_targets if channel_targets is defined else ['conda-forge', 'defaults'] %}
 
 # use this if our build script changes and we need to increment beyond intel's version
-{% set dstbuildnum = '0' %}
+{% set dstbuildnum = '2' %}
 {% set openmp_version = version %}
 # 117 was intel's base build number.  We're up 1 after making the license file not read-only
 {% set openmp_buildnum = buildnum|int + dstbuildnum|int %}
@@ -17,11 +15,11 @@ package:
   version: {{ version }}
 
 source:
-  - url: https://anaconda.org/intel/mkl/{{ mkl_version }}/download/{{ target_platform }}/mkl-{{ mkl_version }}-intel_{{ buildnum }}.tar.bz2
+  - url: https://anaconda.org/intel/mkl/{{ version }}/download/{{ target_platform }}/mkl-{{ version }}-intel_{{ buildnum }}.tar.bz2
     folder: mkl
-  - url: https://anaconda.org/intel/mkl-devel/{{ mkl_version }}/download/{{ target_platform }}/mkl-devel-{{ mkl_version }}-intel_{{ buildnum }}.tar.bz2
+  - url: https://anaconda.org/intel/mkl-devel/{{ version }}/download/{{ target_platform }}/mkl-devel-{{ version }}-intel_{{ buildnum }}.tar.bz2
     folder: mkl-devel
-  - url: https://anaconda.org/intel/mkl-include/{{ mkl_version }}/download/{{ target_platform }}/mkl-include-{{ mkl_version }}-intel_{{ buildnum }}.tar.bz2
+  - url: https://anaconda.org/intel/mkl-include/{{ version }}/download/{{ target_platform }}/mkl-include-{{ version }}-intel_{{ buildnum }}.tar.bz2
     folder: mkl-include
   {% if win or 'conda-forge' not in my_channel_targets %}
   - url: https://anaconda.org/intel/intel-openmp/{{ openmp_version }}/download/{{ target_platform }}/intel-openmp-{{ openmp_version }}-intel_{{ openmp_buildnum }}.tar.bz2
@@ -70,7 +68,6 @@ build:
 
 outputs:
   - name: mkl
-    version: {{ mkl_version }}
     script: repack.sh   # [unix]
     script: repack.bat  # [win]
     requirements:
@@ -102,7 +99,6 @@ outputs:
         - ls -A $PREFIX/lib/*  # [unix]
 
   - name: mkl-include
-    version: {{ mkl_version }}
     script: repack.sh   # [unix]
     script: repack.bat  # [win]
     about:
@@ -161,7 +157,6 @@ outputs:
   {% endif %}
 
   - name: mkl-devel
-    version: {{ mkl_version }}
     script: install-devel.sh   # [unix]
     script: install-devel.bat  # [win]
     build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,8 +7,7 @@
 # use this if our build script changes and we need to increment beyond intel's version
 {% set dstbuildnum = '2' %}
 {% set openmp_version = version %}
-# 117 was intel's base build number.  We're up 1 after making the license file not read-only
-{% set openmp_buildnum = buildnum|int + dstbuildnum|int %}
+{% set openmp_buildnum = buildnum %}
 
 package:
   name: intel_repack
@@ -22,7 +21,7 @@ source:
   - url: https://anaconda.org/intel/mkl-include/{{ version }}/download/{{ target_platform }}/mkl-include-{{ version }}-intel_{{ buildnum }}.tar.bz2
     folder: mkl-include
   {% if win or 'conda-forge' not in my_channel_targets %}
-  - url: https://anaconda.org/intel/intel-openmp/{{ openmp_version }}/download/{{ target_platform }}/intel-openmp-{{ openmp_version }}-intel_{{ openmp_buildnum }}.tar.bz2
+  - url: https://anaconda.org/intel/intel-openmp/{{ openmp_version }}/download/{{ target_platform }}/intel-openmp-{{ openmp_version }}-intel_{{ buildnum }}.tar.bz2
     folder: intel-openmp
   {% endif %}
   {% if target_platform != 'osx-64' %}


### PR DESCRIPTION
This reverts commit 54e23d25d2ec77f2492038eb31db067077089038, reversing
changes made to 50ed5353d18b5e90ad188061eaf90d9bcd7a393a.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
