### PR TITLE
Add version specification to impi outputs

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@
 
 {% set my_channel_targets = channel_targets if channel_targets is defined else ['conda-forge', 'defaults'] %}
 # use this if our build script changes and we need to increment beyond intel's version
-{% set dstbuildnum = '2' %}
+{% set dstbuildnum = '3' %}
 
 package:
   name: intel_repack
@@ -360,6 +360,7 @@ outputs:
         - ls -A $PREFIX/include/*  # [unix or osx]
 
   - name: impi_rt
+    version: {{ impi_version }}
     script: repack.sh   # [unix]
     script: repack.bat  # [win]
     build:
@@ -411,6 +412,7 @@ outputs:
         - if not exist %LIBRARY_BIN%\\impi.dll exit 1  # [win]
 
   - name: impi-devel
+    version: {{ impi_version }}
     script: repack.sh   # [unix]
     script: repack.bat  # [win]
     build:


### PR DESCRIPTION
This PR adds missing ``version`` specification to Intel MPI outputs of the recipe.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
