### PR TITLE
Use LicenseRef-IntelSimplifiedSoftware as SPDX identifier

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,7 +1,3 @@
-c_stdlib:
-- sysroot
-c_stdlib_version:
-- '2.12'
 cdt_name:
 - cos6
 channel_sources:
@@ -14,6 +10,3 @@ mkl:
 - '2023'
 target_platform:
 - linux-64
-zip_keys:
-- - c_stdlib_version
-  - cdt_name

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -1,7 +1,3 @@
-c_stdlib:
-- vs
-c_stdlib_version:
-- '2019'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ About intel_repack
 
 Home: https://github.com/conda-forge/intel_repack-feedstock
 
-Package license: LicenseRef-ProprietaryIntel
+Package license: LicenseRef-IntelSimplifiedSoftware
 
 Summary: Repackaged Intel libraries
 
@@ -18,7 +18,7 @@ About dal
 
 Home: https://www.intel.com/content/www/us/en/developer/tools/oneapi/onedal.html
 
-Package license: LicenseRef-ProprietaryIntel
+Package license: LicenseRef-IntelSimplifiedSoftware
 
 Summary: Intel® oneDAL runtime libraries
 
@@ -35,7 +35,7 @@ About dal-include
 
 Home: https://www.intel.com/content/www/us/en/developer/tools/oneapi/onedal.html
 
-Package license: LicenseRef-ProprietaryIntel
+Package license: LicenseRef-IntelSimplifiedSoftware
 
 Summary: Headers for building against Intel® oneDAL libraries
 
@@ -52,7 +52,7 @@ About impi_rt
 
 Home: https://www.intel.com/content/www/us/en/developer/tools/oneapi/mpi-library.html
 
-Package license: LicenseRef-ProprietaryIntel
+Package license: LicenseRef-IntelSimplifiedSoftware
 
 Summary: Intel® MPI Library
 
@@ -70,7 +70,7 @@ About mkl
 
 Home: https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl.html
 
-Package license: LicenseRef-ProprietaryIntel
+Package license: LicenseRef-IntelSimplifiedSoftware
 
 Summary: Intel® oneAPI Math Kernel Library runtime libraries
 
@@ -85,7 +85,7 @@ About mkl-include
 
 Home: https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl.html
 
-Package license: LicenseRef-ProprietaryIntel
+Package license: LicenseRef-IntelSimplifiedSoftware
 
 Summary: Headers for building against Intel® oneMKL libraries
 
@@ -100,7 +100,7 @@ About dal-devel
 
 Home: https://www.intel.com/content/www/us/en/developer/tools/oneapi/onedal.html
 
-Package license: LicenseRef-ProprietaryIntel
+Package license: LicenseRef-IntelSimplifiedSoftware
 
 Summary: Devel package for building against Intel® oneDAL shared libraries
 
@@ -117,7 +117,7 @@ About dal-static
 
 Home: https://www.intel.com/content/www/us/en/developer/tools/oneapi/onedal.html
 
-Package license: LicenseRef-ProprietaryIntel
+Package license: LicenseRef-IntelSimplifiedSoftware
 
 Summary: Static libraries for Intel® oneDAL
 
@@ -134,7 +134,7 @@ About impi-devel
 
 Home: https://www.intel.com/content/www/us/en/developer/tools/oneapi/mpi-library.html
 
-Package license: LicenseRef-ProprietaryIntel
+Package license: LicenseRef-IntelSimplifiedSoftware
 
 Summary: Devel package for building against Intel® MPI libraries
 
@@ -152,7 +152,7 @@ About mkl-devel
 
 Home: https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl.html
 
-Package license: LicenseRef-ProprietaryIntel
+Package license: LicenseRef-IntelSimplifiedSoftware
 
 Summary: Devel package for building against Intel® oneMKL libraries
 
@@ -165,7 +165,7 @@ About onemkl-sycl-blas
 
 Home: https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl.html
 
-Package license: LicenseRef-ProprietaryIntel
+Package license: LicenseRef-IntelSimplifiedSoftware
 
 Summary: Intel® oneAPI Math Kernel Library runtime libraries
 
@@ -180,7 +180,7 @@ About onemkl-sycl-datafitting
 
 Home: https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl.html
 
-Package license: LicenseRef-ProprietaryIntel
+Package license: LicenseRef-IntelSimplifiedSoftware
 
 Summary: Intel® oneAPI Math Kernel Library runtime libraries
 
@@ -195,7 +195,7 @@ About onemkl-sycl-dft
 
 Home: https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl.html
 
-Package license: LicenseRef-ProprietaryIntel
+Package license: LicenseRef-IntelSimplifiedSoftware
 
 Summary: Intel® oneAPI Math Kernel Library runtime libraries
 
@@ -210,7 +210,7 @@ About onemkl-sycl-rng
 
 Home: https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl.html
 
-Package license: LicenseRef-ProprietaryIntel
+Package license: LicenseRef-IntelSimplifiedSoftware
 
 Summary: Intel® oneAPI Math Kernel Library runtime libraries
 
@@ -225,7 +225,7 @@ About onemkl-sycl-stats
 
 Home: https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl.html
 
-Package license: LicenseRef-ProprietaryIntel
+Package license: LicenseRef-IntelSimplifiedSoftware
 
 Summary: Intel® oneAPI Math Kernel Library runtime libraries
 
@@ -240,7 +240,7 @@ About onemkl-sycl-vm
 
 Home: https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl.html
 
-Package license: LicenseRef-ProprietaryIntel
+Package license: LicenseRef-IntelSimplifiedSoftware
 
 Summary: Intel® oneAPI Math Kernel Library runtime libraries
 
@@ -255,7 +255,7 @@ About onemkl-sycl-lapack
 
 Home: https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl.html
 
-Package license: LicenseRef-ProprietaryIntel
+Package license: LicenseRef-IntelSimplifiedSoftware
 
 Summary: Intel® oneAPI Math Kernel Library runtime libraries
 
@@ -270,7 +270,7 @@ About onemkl-sycl-sparse
 
 Home: https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl.html
 
-Package license: LicenseRef-ProprietaryIntel
+Package license: LicenseRef-IntelSimplifiedSoftware
 
 Summary: Intel® oneAPI Math Kernel Library runtime libraries
 
@@ -285,7 +285,7 @@ About intel-openmp
 
 Home: https://www.intel.com/content/www/us/en/developer/tools/overview.html
 
-Package license: LicenseRef-ProprietaryIntel
+Package license: LicenseRef-IntelSimplifiedSoftware
 
 Summary: Intel® oneAPI Compiler OpenMP runtime
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@
 
 {% set my_channel_targets = channel_targets if channel_targets is defined else ['conda-forge', 'defaults'] %}
 # use this if our build script changes and we need to increment beyond intel's version
-{% set dstbuildnum = '1' %}
+{% set dstbuildnum = '2' %}
 
 package:
   name: intel_repack
@@ -134,7 +134,7 @@ outputs:
       {% endif %}
     about:
       home: https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl.html
-      license: LicenseRef-ProprietaryIntel
+      license: LicenseRef-IntelSimplifiedSoftware
       license_family: Proprietary
       license_file:
          - mkl/info/licenses/license.txt
@@ -157,7 +157,7 @@ outputs:
     number: {{ mkl_buildnum|int + dstbuildnum|int }}
     about:
       home: https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl.html
-      license: LicenseRef-ProprietaryIntel
+      license: LicenseRef-IntelSimplifiedSoftware
       license_family: Proprietary
       license_file:
          - mkl-include/info/licenses/license.txt
@@ -185,7 +185,7 @@ outputs:
         - intel-opencl-rt {{ mkl_version.split('.')[0] }}.*
     about:
       home: https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl.html
-      license: LicenseRef-ProprietaryIntel
+      license: LicenseRef-IntelSimplifiedSoftware
       license_family: Proprietary
       license_file:
          - onemkl-sycl-blas/info/licenses/license.txt
@@ -213,7 +213,7 @@ outputs:
         - intel-opencl-rt {{ mkl_version.split('.')[0] }}.*
     about:
       home: https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl.html
-      license: LicenseRef-ProprietaryIntel
+      license: LicenseRef-IntelSimplifiedSoftware
       license_family: Proprietary
       license_file:
          - onemkl-sycl-datafitting/info/licenses/license.txt
@@ -241,7 +241,7 @@ outputs:
         - intel-opencl-rt {{ mkl_version.split('.')[0] }}.*
     about:
       home: https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl.html
-      license: LicenseRef-ProprietaryIntel
+      license: LicenseRef-IntelSimplifiedSoftware
       license_family: Proprietary
       license_file:
          - onemkl-sycl-dft/info/licenses/license.txt
@@ -270,7 +270,7 @@ outputs:
         - {{ pin_subpackage('onemkl-sycl-blas', exact=True) }}
     about:
       home: https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl.html
-      license: LicenseRef-ProprietaryIntel
+      license: LicenseRef-IntelSimplifiedSoftware
       license_family: Proprietary
       license_file:
          - onemkl-sycl-lapack/info/licenses/license.txt
@@ -298,7 +298,7 @@ outputs:
         - intel-opencl-rt {{ mkl_version.split('.')[0] }}.*
     about:
       home: https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl.html
-      license: LicenseRef-ProprietaryIntel
+      license: LicenseRef-IntelSimplifiedSoftware
       license_family: Proprietary
       license_file:
          - onemkl-sycl-rng/info/licenses/license.txt
@@ -327,7 +327,7 @@ outputs:
         - {{ pin_subpackage('onemkl-sycl-blas', exact=True) }}
     about:
       home: https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl.html
-      license: LicenseRef-ProprietaryIntel
+      license: LicenseRef-IntelSimplifiedSoftware
       license_family: Proprietary
       license_file:
          - onemkl-sycl-sparse/info/licenses/license.txt
@@ -355,7 +355,7 @@ outputs:
         - intel-opencl-rt {{ mkl_version.split('.')[0] }}.*
     about:
       home: https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl.html
-      license: LicenseRef-ProprietaryIntel
+      license: LicenseRef-IntelSimplifiedSoftware
       license_family: Proprietary
       license_file:
          - onemkl-sycl-stats/info/licenses/license.txt
@@ -383,7 +383,7 @@ outputs:
         - intel-opencl-rt {{ mkl_version.split('.')[0] }}.*
     about:
       home: https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl.html
-      license: LicenseRef-ProprietaryIntel
+      license: LicenseRef-IntelSimplifiedSoftware
       license_family: Proprietary
       license_file:
          - onemkl-sycl-vm/info/licenses/license.txt
@@ -407,7 +407,7 @@ outputs:
     version: {{ openmp_version }}
     about:
       home: https://www.intel.com/content/www/us/en/developer/tools/overview.html
-      license: LicenseRef-ProprietaryIntel
+      license: LicenseRef-IntelSimplifiedSoftware
       license_family: Proprietary
       license_file:
          - intel-openmp/info/licenses/license.txt
@@ -465,7 +465,7 @@ outputs:
       description: |
         Intel® oneAPI Math Kernel Library headers and libraries for developing software that uses oneMKL
         This package is a repackaged set of binaries obtained directly from Intel\'s anaconda.org channel.
-      license: LicenseRef-ProprietaryIntel
+      license: LicenseRef-IntelSimplifiedSoftware
       license_family: Proprietary
       license_file:
          - mkl-devel/info/licenses/license.txt
@@ -511,7 +511,7 @@ outputs:
     about:
       home: https://www.intel.com/content/www/us/en/developer/tools/oneapi/onedal.html
       summary: Intel® oneDAL runtime libraries
-      license: LicenseRef-ProprietaryIntel
+      license: LicenseRef-IntelSimplifiedSoftware
       license_family: Proprietary
       license_file:
          - dal/info/licenses/license.txt
@@ -535,7 +535,7 @@ outputs:
     about:
       home: https://www.intel.com/content/www/us/en/developer/tools/oneapi/onedal.html
       summary: Headers for building against Intel® oneDAL libraries
-      license: LicenseRef-ProprietaryIntel
+      license: LicenseRef-IntelSimplifiedSoftware
       license_family: Proprietary
       license_file:
          - dal-include/info/licenses/license.txt
@@ -563,7 +563,7 @@ outputs:
     about:
       home: https://www.intel.com/content/www/us/en/developer/tools/oneapi/onedal.html
       summary: Static libraries for Intel® oneDAL
-      license: LicenseRef-ProprietaryIntel
+      license: LicenseRef-IntelSimplifiedSoftware
       license_family: Proprietary
       license_file:
          - dal-static/info/licenses/license.txt
@@ -596,7 +596,7 @@ outputs:
     about:
       home: https://www.intel.com/content/www/us/en/developer/tools/oneapi/onedal.html
       summary: Devel package for building against Intel® oneDAL shared libraries
-      license: LicenseRef-ProprietaryIntel
+      license: LicenseRef-IntelSimplifiedSoftware
       license_family: Proprietary
       license_file:
          - dal-devel/info/licenses/license.txt
@@ -646,7 +646,7 @@ outputs:
     about:
       home: https://www.intel.com/content/www/us/en/developer/tools/oneapi/mpi-library.html
       summary: Intel® MPI Library
-      license: LicenseRef-ProprietaryIntel
+      license: LicenseRef-IntelSimplifiedSoftware
       license_family: Proprietary
       license_file:
          - impi_rt/info/licenses/license.txt
@@ -684,7 +684,7 @@ outputs:
     about:
       home: https://www.intel.com/content/www/us/en/developer/tools/oneapi/mpi-library.html
       summary: Devel package for building against Intel® MPI libraries
-      license: LicenseRef-ProprietaryIntel
+      license: LicenseRef-IntelSimplifiedSoftware
       license_family: Proprietary
       license_file:
          - impi-devel/info/licenses/license.txt
@@ -712,7 +712,7 @@ outputs:
 # please the linter
 about:
   home: https://github.com/conda-forge/intel_repack-feedstock
-  license: LicenseRef-ProprietaryIntel
+  license: LicenseRef-IntelSimplifiedSoftware
   summary: 'Repackaged Intel libraries'
 
 extra:


### PR DESCRIPTION
This allows us to differentiate the license of these packages from other proprietary Intel packages with a different license.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
