### PR TITLE
Add support for onemkl-license package

### DIFF
--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -11,15 +11,19 @@ jobs:
       win_64_python3.10.____cpython:
         CONFIG: win_64_python3.10.____cpython
         UPLOAD_PACKAGES: 'True'
+        store_build_artifacts: false
       win_64_python3.11.____cpython:
         CONFIG: win_64_python3.11.____cpython
         UPLOAD_PACKAGES: 'True'
+        store_build_artifacts: false
       win_64_python3.12.____cpython:
         CONFIG: win_64_python3.12.____cpython
         UPLOAD_PACKAGES: 'True'
+        store_build_artifacts: false
       win_64_python3.13.____cp313:
         CONFIG: win_64_python3.13.____cp313
         UPLOAD_PACKAGES: 'True'
+        store_build_artifacts: false
   timeoutInMinutes: 360
   variables:
     CONDA_BLD_PATH: C:\\bld\\

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -23,21 +23,25 @@ jobs:
       matrix:
         include:
           - CONFIG: linux_64_python3.10.____cpython
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-alma-x86_64:8
           - CONFIG: linux_64_python3.11.____cpython
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-alma-x86_64:8
           - CONFIG: linux_64_python3.12.____cpython
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-alma-x86_64:8
           - CONFIG: linux_64_python3.13.____cp313
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
@@ -114,7 +118,7 @@ jobs:
       env:
         # default value; make it explicit, as it needs to match with artefact
         # generation below. Not configurable for now, can be revisited later
-        CONDA_BLD_DIR: C:\bld
+        CONDA_BLD_PATH: C:\bld
         MINIFORGE_HOME: ${{ contains(runner.arch, 'ARM') && 'C' || 'D' }}:\Miniforge
         PYTHONUNBUFFERED: 1
         CONFIG: ${{ matrix.CONFIG }}

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -11,6 +11,8 @@ source .scripts/logging_utils.sh
 
 set -xeo pipefail
 
+DOCKER_EXECUTABLE="${DOCKER_EXECUTABLE:-docker}"
+
 THISDIR="$( cd "$( dirname "$0" )" >/dev/null && pwd )"
 PROVIDER_DIR="$(basename "$THISDIR")"
 
@@ -27,7 +29,7 @@ if [[ "${sha:-}" == "" ]]; then
   popd
 fi
 
-docker info
+${DOCKER_EXECUTABLE} info
 
 # In order for the conda-build process in the container to write to the mounted
 # volumes, we need to run with the same id as the host machine, which is
@@ -35,6 +37,7 @@ docker info
 export HOST_USER_ID=$(id -u)
 # Check if docker-machine is being used (normally on OSX) and get the uid from
 # the VM
+
 if hash docker-machine 2> /dev/null && docker-machine active > /dev/null; then
     export HOST_USER_ID=$(docker-machine ssh $(docker-machine active) id -u)
 fi
@@ -76,16 +79,34 @@ if [ -z "${CI}" ]; then
     DOCKER_RUN_ARGS="-it ${DOCKER_RUN_ARGS}"
 fi
 
-( endgroup "Configure Docker" ) 2> /dev/null
+# Default volume suffix for Docker (preserve original behavior)
+VOLUME_SUFFIX=",z"
 
+# Podman-specific handling
+if [ "${DOCKER_EXECUTABLE}" = "podman" ]; then
+    # Fix file permissions for rootless podman builds
+    podman unshare chown -R ${HOST_USER_ID}:${HOST_USER_ID} "${ARTIFACTS}"
+    podman unshare chown -R ${HOST_USER_ID}:${HOST_USER_ID} "${RECIPE_ROOT}"
+
+    # Add SELinux label only if enforcing
+    if command -v getenforce &>/dev/null && [ "$(getenforce)" = "Enforcing" ]; then
+        VOLUME_SUFFIX=",z"
+    else
+        VOLUME_SUFFIX=""
+    fi
+fi
+
+( endgroup "Configure Docker" ) 2> /dev/null
 ( startgroup "Start Docker" ) 2> /dev/null
 
 export UPLOAD_PACKAGES="${UPLOAD_PACKAGES:-True}"
 export IS_PR_BUILD="${IS_PR_BUILD:-False}"
-docker pull "${DOCKER_IMAGE}"
-docker run ${DOCKER_RUN_ARGS} \
-           -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw,z,delegated \
-           -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw,z,delegated \
+
+${DOCKER_EXECUTABLE} pull "${DOCKER_IMAGE}"
+
+${DOCKER_EXECUTABLE} run ${DOCKER_RUN_ARGS} \
+           -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw${VOLUME_SUFFIX},delegated \
+           -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw${VOLUME_SUFFIX},delegated \
            -e CONFIG \
            -e HOST_USER_ID \
            -e UPLOAD_PACKAGES \

--- a/README.md
+++ b/README.md
@@ -264,6 +264,21 @@ CPUs, GPUs, and FPGAs.
 This package is a repackaged set of binaries obtained directly from Intel\'s conda channel.
 
 
+About onemkl-license
+--------------------
+
+Home: https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl.html
+
+Package license: LicenseRef-IntelSimplifiedSoftwareOct2022
+
+Summary: License package for Intel® oneMKL
+
+Documentation: https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl.html
+
+Intel® oneAPI Math Kernel Library license package.
+This package is a repackaged set of binaries obtained directly from Intel\'s conda channel.
+
+
 About onemkl-sycl-blas
 ----------------------
 
@@ -499,6 +514,7 @@ Current release info
 | [![Conda Recipe](https://img.shields.io/badge/recipe-mkl--include-green.svg)](https://anaconda.org/conda-forge/mkl-include) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/mkl-include.svg)](https://anaconda.org/conda-forge/mkl-include) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/mkl-include.svg)](https://anaconda.org/conda-forge/mkl-include) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/mkl-include.svg)](https://anaconda.org/conda-forge/mkl-include) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-mkl--static-green.svg)](https://anaconda.org/conda-forge/mkl-static) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/mkl-static.svg)](https://anaconda.org/conda-forge/mkl-static) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/mkl-static.svg)](https://anaconda.org/conda-forge/mkl-static) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/mkl-static.svg)](https://anaconda.org/conda-forge/mkl-static) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-onedpl--devel-green.svg)](https://anaconda.org/conda-forge/onedpl-devel) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/onedpl-devel.svg)](https://anaconda.org/conda-forge/onedpl-devel) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/onedpl-devel.svg)](https://anaconda.org/conda-forge/onedpl-devel) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/onedpl-devel.svg)](https://anaconda.org/conda-forge/onedpl-devel) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-onemkl--license-green.svg)](https://anaconda.org/conda-forge/onemkl-license) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/onemkl-license.svg)](https://anaconda.org/conda-forge/onemkl-license) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/onemkl-license.svg)](https://anaconda.org/conda-forge/onemkl-license) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/onemkl-license.svg)](https://anaconda.org/conda-forge/onemkl-license) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-onemkl--sycl--blas-green.svg)](https://anaconda.org/conda-forge/onemkl-sycl-blas) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/onemkl-sycl-blas.svg)](https://anaconda.org/conda-forge/onemkl-sycl-blas) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/onemkl-sycl-blas.svg)](https://anaconda.org/conda-forge/onemkl-sycl-blas) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/onemkl-sycl-blas.svg)](https://anaconda.org/conda-forge/onemkl-sycl-blas) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-onemkl--sycl--datafitting-green.svg)](https://anaconda.org/conda-forge/onemkl-sycl-datafitting) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/onemkl-sycl-datafitting.svg)](https://anaconda.org/conda-forge/onemkl-sycl-datafitting) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/onemkl-sycl-datafitting.svg)](https://anaconda.org/conda-forge/onemkl-sycl-datafitting) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/onemkl-sycl-datafitting.svg)](https://anaconda.org/conda-forge/onemkl-sycl-datafitting) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-onemkl--sycl--dft-green.svg)](https://anaconda.org/conda-forge/onemkl-sycl-dft) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/onemkl-sycl-dft.svg)](https://anaconda.org/conda-forge/onemkl-sycl-dft) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/onemkl-sycl-dft.svg)](https://anaconda.org/conda-forge/onemkl-sycl-dft) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/onemkl-sycl-dft.svg)](https://anaconda.org/conda-forge/onemkl-sycl-dft) |
@@ -519,16 +535,16 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `dal, dal-devel, dal-include, dal-static, impi-devel, impi_rt, intel-openmp, mkl, mkl-devel, mkl-devel-dpcpp, mkl-dpcpp, mkl-include, mkl-static, onedpl-devel, onemkl-sycl-blas, onemkl-sycl-datafitting, onemkl-sycl-dft, onemkl-sycl-include, onemkl-sycl-lapack, onemkl-sycl-rng, onemkl-sycl-sparse, onemkl-sycl-stats, onemkl-sycl-vm` can be installed with `conda`:
+Once the `conda-forge` channel has been enabled, `dal, dal-devel, dal-include, dal-static, impi-devel, impi_rt, intel-openmp, mkl, mkl-devel, mkl-devel-dpcpp, mkl-dpcpp, mkl-include, mkl-static, onedpl-devel, onemkl-license, onemkl-sycl-blas, onemkl-sycl-datafitting, onemkl-sycl-dft, onemkl-sycl-include, onemkl-sycl-lapack, onemkl-sycl-rng, onemkl-sycl-sparse, onemkl-sycl-stats, onemkl-sycl-vm` can be installed with `conda`:
 
 ```
-conda install dal dal-devel dal-include dal-static impi-devel impi_rt intel-openmp mkl mkl-devel mkl-devel-dpcpp mkl-dpcpp mkl-include mkl-static onedpl-devel onemkl-sycl-blas onemkl-sycl-datafitting onemkl-sycl-dft onemkl-sycl-include onemkl-sycl-lapack onemkl-sycl-rng onemkl-sycl-sparse onemkl-sycl-stats onemkl-sycl-vm
+conda install dal dal-devel dal-include dal-static impi-devel impi_rt intel-openmp mkl mkl-devel mkl-devel-dpcpp mkl-dpcpp mkl-include mkl-static onedpl-devel onemkl-license onemkl-sycl-blas onemkl-sycl-datafitting onemkl-sycl-dft onemkl-sycl-include onemkl-sycl-lapack onemkl-sycl-rng onemkl-sycl-sparse onemkl-sycl-stats onemkl-sycl-vm
 ```
 
 or with `mamba`:
 
 ```
-mamba install dal dal-devel dal-include dal-static impi-devel impi_rt intel-openmp mkl mkl-devel mkl-devel-dpcpp mkl-dpcpp mkl-include mkl-static onedpl-devel onemkl-sycl-blas onemkl-sycl-datafitting onemkl-sycl-dft onemkl-sycl-include onemkl-sycl-lapack onemkl-sycl-rng onemkl-sycl-sparse onemkl-sycl-stats onemkl-sycl-vm
+mamba install dal dal-devel dal-include dal-static impi-devel impi_rt intel-openmp mkl mkl-devel mkl-devel-dpcpp mkl-dpcpp mkl-include mkl-static onedpl-devel onemkl-license onemkl-sycl-blas onemkl-sycl-datafitting onemkl-sycl-dft onemkl-sycl-include onemkl-sycl-lapack onemkl-sycl-rng onemkl-sycl-sparse onemkl-sycl-stats onemkl-sycl-vm
 ```
 
 It is possible to list all of the versions of `dal` available on your platform with `conda`:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -153,9 +153,7 @@ outputs:
       doc_url: https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl.html
     test:
       commands:
-        - ls -A $PREFIX/pkgs/onemkl-license/info/*  # [linux]
-        - test -f $PREFIX/pkgs/onemkl-license/info/license.txt  # [linux]
-        - if not exist %PREFIX%\pkgs\onemkl-license\info\license.txt exit 1  # [win]
+        - echo 'onemkl-license installed successfully'
 
   - name: mkl
     version: {{ mkl_version }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -65,6 +65,9 @@ source:
   - url: {{ intel_ch }}/{{ target_platform }}/mkl-static-{{ mkl_version }}-intel_{{ mkl_buildnum }}.conda
     folder: mkl-static
     no_hoist: true
+  - url: {{ intel_ch }}/{{ target_platform }}/onemkl-license-{{ mkl_version }}-intel_{{ mkl_buildnum }}.conda
+    folder: onemkl-license
+    no_hoist: true
   - url: {{ intel_ch }}/{{ target_platform }}/onemkl-sycl-blas-{{ mkl_version }}-intel_{{ mkl_buildnum }}.conda
     folder: onemkl-sycl-blas
     no_hoist: true
@@ -131,6 +134,29 @@ build:
   skip: True                                  # [not (linux64 or win)]
 
 outputs:
+  - name: onemkl-license
+    version: {{ mkl_version }}
+    script: repack.sh   # [linux]
+    script: repack.bat  # [win]
+    number: {{ mkl_buildnum|int + dstbuildnum|int }}
+    about:
+      home: https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl.html
+      license: LicenseRef-IntelSimplifiedSoftwareOct2022
+      license_family: Proprietary
+      license_file:
+         - onemkl-license/info/licenses/license.txt
+         - onemkl-license/info/licenses/tpp.txt
+      summary: License package for Intel® oneMKL
+      description: |
+        Intel® oneAPI Math Kernel Library license package.
+        This package is a repackaged set of binaries obtained directly from Intel\'s conda channel.
+      doc_url: https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl.html
+    test:
+      commands:
+        - ls -A $PREFIX/pkgs/onemkl-license/info/*  # [linux]
+        - test -f $PREFIX/pkgs/onemkl-license/info/license.txt  # [linux]
+        - if not exist %PREFIX%\pkgs\onemkl-license\info\license.txt exit 1  # [win]
+
   - name: mkl
     version: {{ mkl_version }}
     script: repack.sh   # [linux]
@@ -145,13 +171,15 @@ outputs:
         {{ openmp_mutex }}
       host:
         - tbb-devel {{ tbb_version.split('.')[0] }}.*
+      run:
+        - {{ pin_subpackage('onemkl-license', exact=True) }}
     about:
       home: https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl.html
       license: LicenseRef-IntelSimplifiedSoftwareOct2022
       license_family: Proprietary
       license_file:
-         - mkl/info/licenses/license.txt
-         - mkl/info/licenses/tpp.txt
+         - onemkl-license/info/licenses/license.txt
+         - onemkl-license/info/licenses/tpp.txt
       summary: Intel® oneAPI Math Kernel Library runtime libraries
       description: |
         Intel® oneAPI Math Kernel Library is Intel®-Optimized Math Library for Numerical Computing on CPUs & GPUs
@@ -168,13 +196,16 @@ outputs:
     script: repack.sh   # [linux]
     script: repack.bat  # [win]
     number: {{ mkl_buildnum|int + dstbuildnum|int }}
+    requirements:
+      run:
+        - {{ pin_subpackage('onemkl-license', exact=True) }}
     about:
       home: https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl.html
       license: LicenseRef-IntelSimplifiedSoftwareOct2022
       license_family: Proprietary
       license_file:
-         - mkl-include/info/licenses/license.txt
-         - mkl-include/info/licenses/tpp.txt
+         - onemkl-license/info/licenses/license.txt
+         - onemkl-license/info/licenses/tpp.txt
       summary: Headers for building against Intel® oneMKL libraries
       description: |
         Intel® oneAPI Math Kernel Library headers for developing software that uses oneMKL
@@ -223,8 +254,8 @@ outputs:
       license: LicenseRef-IntelSimplifiedSoftwareOct2022
       license_family: Proprietary
       license_file:
-         - onemkl-sycl-blas/info/licenses/license.txt
-         - onemkl-sycl-blas/info/licenses/tpp.txt
+         - onemkl-license/info/licenses/license.txt
+         - onemkl-license/info/licenses/tpp.txt
       summary: Intel® oneAPI Math Kernel Library runtime libraries
       description: |
         Intel® oneAPI Math Kernel Library is Intel®-Optimized Math Library for Numerical Computing on CPUs & GPUs
@@ -273,8 +304,8 @@ outputs:
       license: LicenseRef-IntelSimplifiedSoftwareOct2022
       license_family: Proprietary
       license_file:
-         - onemkl-sycl-datafitting/info/licenses/license.txt
-         - onemkl-sycl-datafitting/info/licenses/tpp.txt
+         - onemkl-license/info/licenses/license.txt
+         - onemkl-license/info/licenses/tpp.txt
       summary: Intel® oneAPI Math Kernel Library runtime libraries
       description: |
         Intel® oneAPI Math Kernel Library is Intel®-Optimized Math Library for Numerical Computing on CPUs & GPUs
@@ -323,8 +354,8 @@ outputs:
       license: LicenseRef-IntelSimplifiedSoftwareOct2022
       license_family: Proprietary
       license_file:
-         - onemkl-sycl-dft/info/licenses/license.txt
-         - onemkl-sycl-dft/info/licenses/tpp.txt
+         - onemkl-license/info/licenses/license.txt
+         - onemkl-license/info/licenses/tpp.txt
       summary: Intel® oneAPI Math Kernel Library runtime libraries
       description: |
         Intel® oneAPI Math Kernel Library is Intel®-Optimized Math Library for Numerical Computing on CPUs & GPUs
@@ -375,8 +406,8 @@ outputs:
       license: LicenseRef-IntelSimplifiedSoftwareOct2022
       license_family: Proprietary
       license_file:
-         - onemkl-sycl-lapack/info/licenses/license.txt
-         - onemkl-sycl-lapack/info/licenses/tpp.txt
+         - onemkl-license/info/licenses/license.txt
+         - onemkl-license/info/licenses/tpp.txt
       summary: Intel® oneAPI Math Kernel Library runtime libraries
       description: |
         Intel® oneAPI Math Kernel Library is Intel®-Optimized Math Library for Numerical Computing on CPUs & GPUs
@@ -425,8 +456,8 @@ outputs:
       license: LicenseRef-IntelSimplifiedSoftwareOct2022
       license_family: Proprietary
       license_file:
-         - onemkl-sycl-rng/info/licenses/license.txt
-         - onemkl-sycl-rng/info/licenses/tpp.txt
+         - onemkl-license/info/licenses/license.txt
+         - onemkl-license/info/licenses/tpp.txt
       summary: Intel® oneAPI Math Kernel Library runtime libraries
       description: |
         Intel® oneAPI Math Kernel Library is Intel®-Optimized Math Library for Numerical Computing on CPUs & GPUs
@@ -477,8 +508,8 @@ outputs:
       license: LicenseRef-IntelSimplifiedSoftwareOct2022
       license_family: Proprietary
       license_file:
-         - onemkl-sycl-sparse/info/licenses/license.txt
-         - onemkl-sycl-sparse/info/licenses/tpp.txt
+         - onemkl-license/info/licenses/license.txt
+         - onemkl-license/info/licenses/tpp.txt
       summary: Intel® oneAPI Math Kernel Library runtime libraries
       description: |
         Intel® oneAPI Math Kernel Library is Intel®-Optimized Math Library for Numerical Computing on CPUs & GPUs
@@ -527,8 +558,8 @@ outputs:
       license: LicenseRef-IntelSimplifiedSoftwareOct2022
       license_family: Proprietary
       license_file:
-         - onemkl-sycl-stats/info/licenses/license.txt
-         - onemkl-sycl-stats/info/licenses/tpp.txt
+         - onemkl-license/info/licenses/license.txt
+         - onemkl-license/info/licenses/tpp.txt
       summary: Intel® oneAPI Math Kernel Library runtime libraries
       description: |
         Intel® oneAPI Math Kernel Library is Intel®-Optimized Math Library for Numerical Computing on CPUs & GPUs
@@ -577,8 +608,8 @@ outputs:
       license: LicenseRef-IntelSimplifiedSoftwareOct2022
       license_family: Proprietary
       license_file:
-         - onemkl-sycl-vm/info/licenses/license.txt
-         - onemkl-sycl-vm/info/licenses/tpp.txt
+         - onemkl-license/info/licenses/license.txt
+         - onemkl-license/info/licenses/tpp.txt
       summary: Intel® oneAPI Math Kernel Library runtime libraries
       description: |
         Intel® oneAPI Math Kernel Library is Intel®-Optimized Math Library for Numerical Computing on CPUs & GPUs
@@ -600,8 +631,8 @@ outputs:
       license: LicenseRef-IntelSimplifiedSoftwareOct2022
       license_family: Proprietary
       license_file:
-         - onemkl-sycl-include/info/licenses/license.txt
-         - onemkl-sycl-include/info/licenses/tpp.txt
+         - onemkl-license/info/licenses/license.txt
+         - onemkl-license/info/licenses/tpp.txt
       summary: Headers for building against Intel® oneMKL oneAPI interface libraries
       description: |
         Intel® oneAPI Math Kernel Library oneAPI interface headers for developing software that uses oneMKL
@@ -636,8 +667,8 @@ outputs:
       license: LicenseRef-IntelSimplifiedSoftwareOct2022
       license_family: Proprietary
       license_file:
-         - mkl-dpcpp/info/licenses/license.txt
-         - mkl-dpcpp/info/licenses/tpp.txt
+         - onemkl-license/info/licenses/license.txt
+         - onemkl-license/info/licenses/tpp.txt
       summary: Intel® oneAPI Math Kernel Library dpcpp libraries
       description: |
         Intel® oneAPI Math Kernel Library is Intel®-Optimized Math Library for Numerical Computing on CPUs & GPUs
@@ -652,7 +683,7 @@ outputs:
     number: {{ mkl_buildnum|int + dstbuildnum|int + 1|int }}
     build:
       script:
-        - cp -f $SRC_DIR/mkl/info/licenses/license.txt $SRC_DIR  # [linux]
+        - cp -f $SRC_DIR/onemkl-license/info/licenses/license.txt $SRC_DIR  # [linux]
         - chmod 664 $SRC_DIR/license.txt  # [linux]
         - cp -rv $SRC_DIR/$PKG_NAME/* $PREFIX  # [linux]
         - rm -rf $PREFIX/info  # [linux]
@@ -677,8 +708,8 @@ outputs:
       license: LicenseRef-IntelSimplifiedSoftwareOct2022
       license_family: Proprietary
       license_file:
-         - mkl-devel-dpcpp/info/licenses/license.txt
-         - mkl-devel-dpcpp/info/licenses/tpp.txt
+         - onemkl-license/info/licenses/license.txt
+         - onemkl-license/info/licenses/tpp.txt
     test:
       commands:
         - ls -A $PREFIX/lib/*  # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,7 @@
 
 {% set intel_ch = "https://software.repos.intel.com/python/conda" %}
 # use this if our build script changes and we need to increment beyond intel's version
-{% set dstbuildnum = '2' %}
+{% set dstbuildnum = '3' %}
 
 
 # More info about OpenMP mutex could be found on conda-forge wiki:


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Changes/Fix
- `onemkl-license` package was added in oneAPI 2025.3 for all python distributions, however, those changes were not propagated to the repack. This PR adds those changes.
- Adding `onemkl-license` package fixes the issue with duplicate license files from `mkl` and `mkl-include` packages when installing them in the same environment.