### PR TITLE
Add mkl constriant when resolving blas, lapack

### DIFF
--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -11,6 +11,8 @@ source .scripts/logging_utils.sh
 
 set -xeo pipefail
 
+DOCKER_EXECUTABLE="${DOCKER_EXECUTABLE:-docker}"
+
 THISDIR="$( cd "$( dirname "$0" )" >/dev/null && pwd )"
 PROVIDER_DIR="$(basename "$THISDIR")"
 
@@ -27,7 +29,7 @@ if [[ "${sha:-}" == "" ]]; then
   popd
 fi
 
-docker info
+${DOCKER_EXECUTABLE} info
 
 # In order for the conda-build process in the container to write to the mounted
 # volumes, we need to run with the same id as the host machine, which is
@@ -35,6 +37,7 @@ docker info
 export HOST_USER_ID=$(id -u)
 # Check if docker-machine is being used (normally on OSX) and get the uid from
 # the VM
+
 if hash docker-machine 2> /dev/null && docker-machine active > /dev/null; then
     export HOST_USER_ID=$(docker-machine ssh $(docker-machine active) id -u)
 fi
@@ -76,16 +79,34 @@ if [ -z "${CI}" ]; then
     DOCKER_RUN_ARGS="-it ${DOCKER_RUN_ARGS}"
 fi
 
-( endgroup "Configure Docker" ) 2> /dev/null
+# Default volume suffix for Docker (preserve original behavior)
+VOLUME_SUFFIX=",z"
 
+# Podman-specific handling
+if [ "${DOCKER_EXECUTABLE}" = "podman" ]; then
+    # Fix file permissions for rootless podman builds
+    podman unshare chown -R ${HOST_USER_ID}:${HOST_USER_ID} "${ARTIFACTS}"
+    podman unshare chown -R ${HOST_USER_ID}:${HOST_USER_ID} "${RECIPE_ROOT}"
+
+    # Add SELinux label only if enforcing
+    if command -v getenforce &>/dev/null && [ "$(getenforce)" = "Enforcing" ]; then
+        VOLUME_SUFFIX=",z"
+    else
+        VOLUME_SUFFIX=""
+    fi
+fi
+
+( endgroup "Configure Docker" ) 2> /dev/null
 ( startgroup "Start Docker" ) 2> /dev/null
 
 export UPLOAD_PACKAGES="${UPLOAD_PACKAGES:-True}"
 export IS_PR_BUILD="${IS_PR_BUILD:-False}"
-docker pull "${DOCKER_IMAGE}"
-docker run ${DOCKER_RUN_ARGS} \
-           -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw,z,delegated \
-           -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw,z,delegated \
+
+${DOCKER_EXECUTABLE} pull "${DOCKER_IMAGE}"
+
+${DOCKER_EXECUTABLE} run ${DOCKER_RUN_ARGS} \
+           -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw${VOLUME_SUFFIX},delegated \
+           -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw${VOLUME_SUFFIX},delegated \
            -e CONFIG \
            -e HOST_USER_ID \
            -e UPLOAD_PACKAGES \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -145,14 +145,6 @@ outputs:
         {{ openmp_mutex }}
       host:
         - tbb-devel {{ tbb_version.split('.')[0] }}.*
-      {% if 'conda-forge' in my_channel_targets %}
-      run_constrained:
-        # If libblas/liblapack are present in the environment they must be backed
-        # by MKL, otherwise BLAS/LAPACK symbol collisions can occur at runtime
-        # (e.g. between MKL and OpenBLAS loaded into the same process).
-        - libblas =*=*mkl
-        - liblapack =*=*mkl
-      {% endif %}
     about:
       home: https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl.html
       license: LicenseRef-IntelSimplifiedSoftwareOct2022
@@ -639,6 +631,16 @@ outputs:
         - {{ pin_subpackage('onemkl-sycl-sparse', exact=True) }}
         - {{ pin_subpackage('onemkl-sycl-stats', exact=True) }}
         - {{ pin_subpackage('onemkl-sycl-vm', exact=True) }}
+      {% if 'conda-forge' in my_channel_targets %}
+      run_constrained:
+        # If libblas/liblapack are present in the environment they must be backed
+        # by MKL, otherwise BLAS/LAPACK symbol collisions can occur at runtime
+        # (e.g. between MKL and OpenBLAS loaded into the same process).
+        - libblas =*=*mkl
+        - libcblas =*=*mkl
+        - liblapack =*=*mkl
+        - liblapacke =*=*mkl
+      {% endif %}
     about:
       home: https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl.html
       license: LicenseRef-IntelSimplifiedSoftwareOct2022

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -145,6 +145,14 @@ outputs:
         {{ openmp_mutex }}
       host:
         - tbb-devel {{ tbb_version.split('.')[0] }}.*
+      {% if 'conda-forge' in my_channel_targets %}
+      run_constrained:
+        # If libblas/liblapack are present in the environment they must be backed
+        # by MKL, otherwise BLAS/LAPACK symbol collisions can occur at runtime
+        # (e.g. between MKL and OpenBLAS loaded into the same process).
+        - libblas =*=*mkl
+        - liblapack =*=*mkl
+      {% endif %}
     about:
       home: https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl.html
       license: LicenseRef-IntelSimplifiedSoftwareOct2022

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,7 @@
 
 {% set intel_ch = "https://software.repos.intel.com/python/conda" %}
 # use this if our build script changes and we need to increment beyond intel's version
-{% set dstbuildnum = '2' %}
+{% set dstbuildnum = '4' %}
 
 
 # More info about OpenMP mutex could be found on conda-forge wiki:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,7 @@
 
 {% set intel_ch = "https://software.repos.intel.com/python/conda" %}
 # use this if our build script changes and we need to increment beyond intel's version
-{% set dstbuildnum = '3' %}
+{% set dstbuildnum = '4' %}
 
 
 # More info about OpenMP mutex could be found on conda-forge wiki:
@@ -682,6 +682,14 @@ outputs:
         - {{ pin_subpackage('onemkl-sycl-sparse', exact=True) }}
         - {{ pin_subpackage('onemkl-sycl-stats', exact=True) }}
         - {{ pin_subpackage('onemkl-sycl-vm', exact=True) }}
+      run_constrained:
+        # If libblas/liblapack are present in the environment they must be backed
+        # by MKL, otherwise BLAS/LAPACK symbol collisions can occur at runtime
+        # (e.g. between MKL and OpenBLAS loaded into the same process).
+        - libblas =*=*mkl
+        - libcblas =*=*mkl
+        - liblapack =*=*mkl
+        - liblapacke =*=*mkl
     about:
       home: https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl.html
       license: LicenseRef-IntelSimplifiedSoftwareOct2022


### PR DESCRIPTION
## Motivation
In conda-forge, packages using BLAS/LAPACK typically do so by linking to metapackages 'libblas' and 'liblapack', which by default in most platforms are not backed by MKL.

Other packages in the ecosystem (like SciPy) might break in subtle ways if a process (like a Python interpreter) loads BLAS/LAPACK symbols from a different vendor than what it expects - e.g. if SciPy expects to load OpenBLAS/pthreads, but instead the process loads symbols with the same name from MKL/openmp, which could happen if another library loads MKL DPC runtimes first.

These issues could be avoided by having the MKL SYCL runtime libraries set a constraint on having 'libblas' and 'liblapack' both being from MKL if they are installed in the same environment.

## Changes
Since `mkl-dpcpp` package resolves by installing `mkl` which could override the default blas/lapack, this PR adds the constraint on the `mkl-dpcpp` package to resolve correctly only if blas/lapack are from `mkl`.

## Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged) - build number `3` is reserved for the changes in #129.
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

