### PR TITLE
re-add tbb-devel and toolchain reqs to dal

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,7 @@
 
 {% set intel_ch = "https://software.repos.intel.com/python/conda" %}
 # use this if our build script changes and we need to increment beyond intel's version
-{% set dstbuildnum = '5' %}
+{% set dstbuildnum = '6' %}
 
 
 # More info about OpenMP mutex could be found on conda-forge wiki:
@@ -896,8 +896,12 @@ outputs:
       binary_relocation: false
       detect_binary_files_with_prefix: false
     requirements:
+      build:
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
+        - {{ stdlib('c') }}
       host:
-        - tbb {{ tbb_version.split('.')[0] }}.*
+        - tbb-devel {{ tbb_version.split('.')[0] }}.*
 
     about:
       home: https://github.com/uxlfoundation/oneDAL
@@ -940,8 +944,12 @@ outputs:
         - khronos-opencl-icd-loader  # [win]
         - intel-opencl-rt
     requirements:
+      build:
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
+        - {{ stdlib('c') }}
       host:
-        - dal {{ dal_version }}
+        - {{ pin_subpackage('dal', exact=True) }}
         - mkl-dpcpp {{ dal_version.split('.')[0] }}.*
         - intel-sycl-rt {{ dal_version.split('.')[0] }}.*
         - intel-cmplr-lib-rt {{ dal_version.split('.')[0] }}.*


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

#134 dropped the `build:` block from the dal and dal-gpu outputs and changed `host: tbb-devel` to `host: tbb`. This unintentionally removed the run_exports-driven runtime dependencies, leaving the published _995 artifacts with empty `depends: []` missing tbb, libgcc/libstdcxx, vc14_runtime/ucrt, etc. Downstream symptom: import _daal4py fails with ImportError: DLL load failed on Windows because tbb12.dll is never installed alongside dal. example: https://dev.azure.com/daal/daal4py/_build/results?buildId=59512&view=logs&j=ba7a3e8a-b47e-576a-4e2c-7d34c550b607&t=96a46c6b-4c47-5a80-e753-1b93a36892b3&l=173. This PR restores the pre-#134 pattern (mirrors the mkl output): compiler('c') + compiler('cxx') + stdlib('c') in build:, and tbb-devel in host:. Verified locally: rebuilt dal now has depends: [__glibc, libgcc, libstdcxx, tbb >=2023.0.0]