### PR TITLE
State runtime dependencies for `dal-gpu` under correct place

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,7 @@
 
 {% set intel_ch = "https://software.repos.intel.com/python/conda" %}
 # use this if our build script changes and we need to increment beyond intel's version
-{% set dstbuildnum = '6' %}
+{% set dstbuildnum = '7' %}
 
 
 # More info about OpenMP mutex could be found on conda-forge wiki:
@@ -949,7 +949,6 @@ outputs:
         - {{ compiler('cxx') }}
         - {{ stdlib('c') }}
       host:
-        - {{ pin_subpackage('dal', exact=True) }}
         - mkl-dpcpp {{ dal_version.split('.')[0] }}.*
         - intel-sycl-rt {{ dal_version.split('.')[0] }}.*
         - intel-cmplr-lib-rt {{ dal_version.split('.')[0] }}.*
@@ -958,6 +957,9 @@ outputs:
         # cpu runtime
         - intel-opencl-rt {{ dal_version.split('.')[0] }}.*
         {{ openmp_mutex }}
+      run:
+        - {{ pin_subpackage('dal', exact=True) }}
+        - mkl-dpcpp {{ dal_version.split('.')[0] }}.*
       run_constrained:
         - {{ pin_compatible('intel-sycl-rt') }}
         - {{ pin_compatible('intel-cmplr-lib-rt') }}


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Previous PR for `dal-gpu` added MKL-DPC and DAL dependencies under 'host', but looks like that didn't propagate them into runtime requirements. This PR puts those dependencies under `run` instead.

CC @ethanglaser 